### PR TITLE
Current event refactor

### DIFF
--- a/react-client/src/components/CurrentEvents.jsx
+++ b/react-client/src/components/CurrentEvents.jsx
@@ -14,9 +14,17 @@ class CurrentEvents extends React.Component {
 	}
 
 	componentDidMount() {
-		utils.getEventsByUser(data => {
+		utils.getEventsByUser(events => {
+			var upcomingEvents = [];
+			events.forEach((events) => {
+				if (new Date(events.date) > new Date()) {
+					upcomingEvents.push(events);
+				}
+			});			
 			this.setState({
-				events: data
+				events: upcomingEvents.sort((a,b) => {
+					return new Date(a.date) > new Date(b.date);
+				})
 			})
 		})
 	}

--- a/react-client/src/components/CurrentEvents.jsx
+++ b/react-client/src/components/CurrentEvents.jsx
@@ -2,23 +2,31 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ShowNeedsHost from './ShowNeedsHost.jsx';
 import $ from 'jquery';
+import utils from '../utils.js';
 
 class CurrentEvents extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
 			isHidden: true,
-			showEvent: 0
+			events: []		
 		}
 	}
 
+	componentDidMount() {
+		utils.getEventsByUser(data => {
+			this.setState({
+				events: data
+			})
+		})
+	}
 
 
 	render() {
 		return (
 			<div>
 				{
-				this.props.events.map((event, idx) =>
+				this.state.events.map((event, idx) =>
 					<ShowNeedsHost event={event} idx={idx}/>
 				)
 			}

--- a/react-client/src/components/PastEvents.jsx
+++ b/react-client/src/components/PastEvents.jsx
@@ -8,6 +8,8 @@ class PastEvents extends React.Component {
 		}
 	}
 
+	
+
 	render() {
 		return (
 			<div className='current-events'>

--- a/react-client/src/components/hosts.jsx
+++ b/react-client/src/components/hosts.jsx
@@ -19,7 +19,6 @@ class Hosts extends React.Component {
     utils.getEventsByUser(data => {
 			var currentData = [];
 			var pastData = [];
-			console.log(data);
 			data.forEach(function(data) {
 				if (new Date(data.date) > new Date()) {
 					currentData.push(data);

--- a/react-client/src/components/hosts.jsx
+++ b/react-client/src/components/hosts.jsx
@@ -36,20 +36,9 @@ class Hosts extends React.Component {
         
 	showTab(tab) {
 
-    if (tab === 'current') {
-      utils.getEventsByUser(data => {
-
-        this.setState({
-          events: data,
-          showTab: tab
-        });
-
-      });
-    } else {
-  		this.setState({
+  this.setState({
   			showTab: tab
-  		});
-    }
+    })
 	}
 
 
@@ -74,7 +63,7 @@ class Hosts extends React.Component {
 
 				<div>
 
-					{this.state.showTab === 'current' ? <CurrentEvents events={this.state.current}/> : null}
+					{this.state.showTab === 'current' ? <CurrentEvents/> : null}
 					{this.state.showTab === 'create' ? <CreateEvent/> : null}
 					{this.state.showTab === 'past' ? <PastEvents events={this.state.past} /> : null}
 


### PR DESCRIPTION
Display only upcoming events, descending order by the most recent upcoming events, and fix the bug that lagged on the seeing the most updated events. 